### PR TITLE
fix: persist previous state when document model name changes

### DIFF
--- a/editors/document-model/editor-schema.tsx
+++ b/editors/document-model/editor-schema.tsx
@@ -20,6 +20,8 @@ interface IProps extends SchemaEditorProps {
     theme: styles.ColorTheme;
 }
 
+const typeRegexp = /^type (\S*State)( })?/g;
+
 export default function EditorSchema({
     name,
     onGenerate,
@@ -34,14 +36,25 @@ export default function EditorSchema({
     const scopeSchemaContent = scope === 'global' ? ' {\n\t\n}' : '';
 
     useEffect(() => {
-        if (
-            !code.includes(`type ${pascalCase(name)}${scopeStateName}State {`)
-        ) {
+        if (!code) {
+            // Set initial code value if empty
             setCode(
                 `type ${pascalCase(
                     name,
                 )}${scopeStateName}State${scopeSchemaContent}`,
             );
+        } else if (
+            !code.includes(`type ${pascalCase(name)}${scopeStateName}State {`)
+        ) {
+            // Update type name value if name changed
+            const newCodeValue = code.replace(typeRegexp, (match, group1) => {
+                return match.replace(
+                    group1,
+                    `${pascalCase(name)}${scopeStateName}State`,
+                );
+            });
+
+            setCode(newCodeValue);
         }
     }, [name]);
 

--- a/editors/document-model/editor.tsx
+++ b/editors/document-model/editor.tsx
@@ -69,7 +69,6 @@ function Editor(props: IProps) {
 
     const setModelName = (name: string) => {
         dispatch(actions.setModelName({ name }));
-        dispatch(actions.setName(name));
     };
 
     const setAuthorName = (authorName: string) => {

--- a/editors/document-model/editor.tsx
+++ b/editors/document-model/editor.tsx
@@ -46,6 +46,13 @@ function Editor(props: IProps) {
         if (ops.length < 1) {
             dispatch(actions.setModelId({ id: '' }));
         }
+
+        const globalOps = document.operations.global;
+        const latestGlobalOp = globalOps[globalOps.length - 1];
+
+        if (latestGlobalOp && latestGlobalOp.type === 'SET_MODEL_NAME') {
+            dispatch(actions.setName(latestGlobalOp.input.name));
+        }
     }, [document.operations]);
 
     const setModelId = (id: string) => {

--- a/editors/document-model/editor.tsx
+++ b/editors/document-model/editor.tsx
@@ -69,6 +69,7 @@ function Editor(props: IProps) {
 
     const setModelName = (name: string) => {
         dispatch(actions.setModelName({ name }));
+        dispatch(actions.setName(name));
     };
 
     const setAuthorName = (authorName: string) => {


### PR DESCRIPTION
## Description:

- Persist previous state when document model name changes

> **NOTE**: this PR depends on https://github.com/powerhouse-inc/document-model-libs/pull/35

![2024-01-02 12 42 22](https://github.com/powerhouse-inc/document-model-libs/assets/20387722/298591b9-8acb-4465-9cac-a9d58b2b6148)
