### PR TITLE
fix: avoid hook infinite loop when set document initial state

### DIFF
--- a/editors/document-model/editor-initital-state.tsx
+++ b/editors/document-model/editor-initital-state.tsx
@@ -3,17 +3,20 @@ import { editor } from 'monaco-editor';
 import { useEffect, useRef, useState } from 'react';
 import { z } from 'zod';
 import { styles } from 'document-model-editors';
+import { isJSONEqual } from '../common/json-editor';
 
 interface IProps extends EditorProps {
     validator?: () => z.AnyZodObject;
     onCreate: (create: string) => void;
     theme: styles.ColorTheme;
+    setInitialValue?: boolean;
 }
 
 export default function EditorInitialState({
     validator,
     onCreate,
     theme,
+    setInitialValue,
     ...props
 }: IProps) {
     const [code, setCode] = useState(props.value || '{}');
@@ -28,6 +31,15 @@ export default function EditorInitialState({
             onCreate(value);
         });
     }, [editorRef.current]);
+
+    useEffect(() => {
+        if (
+            setInitialValue &&
+            !isJSONEqual(JSON.parse(props.value || '{}'), code)
+        ) {
+            setCode(props.value || '{}');
+        }
+    }, [setInitialValue, props.value]);
 
     let errorMessage = '';
     let valid = false;

--- a/editors/document-model/editor-state.tsx
+++ b/editors/document-model/editor-state.tsx
@@ -1,8 +1,9 @@
-import { OperationScope } from 'document-model/document';
+import { OperationScope, Operation, BaseAction } from 'document-model/document';
 import { styles } from 'document-model-editors';
 import EditorSchema, { ScopeType } from './editor-schema';
 import EditorInitialState from './editor-initital-state';
 import { SchemaResult } from './useSchemaEditor';
+import { DocumentModelAction } from 'document-model/document-model';
 
 export interface EditorStateProps {
     name: string;
@@ -10,10 +11,18 @@ export interface EditorStateProps {
     scope: OperationScope;
     theme: styles.ColorTheme;
     setStateSchema: (schema: string, scope: ScopeType) => void;
+    latestOperation?: Operation<DocumentModelAction | BaseAction> | null;
 }
 
 function EditorState(props: EditorStateProps) {
-    const { name, theme, setStateSchema, scope, schemaHandlers } = props;
+    const {
+        name,
+        theme,
+        setStateSchema,
+        scope,
+        schemaHandlers,
+        latestOperation,
+    } = props;
 
     const { setInitialValue, setSchemaState, schemaState, specification } =
         schemaHandlers;
@@ -66,6 +75,10 @@ function EditorState(props: EditorStateProps) {
                 >{`${scopeName} Initial State`}</h4>
                 <EditorInitialState
                     height={200}
+                    setInitialValue={
+                        latestOperation?.type === 'SET_INITIAL_STATE' &&
+                        latestOperation?.scope === scope
+                    }
                     value={specification?.state[scope].initialValue}
                     validator={schemaState?.validator}
                     onCreate={value => {

--- a/editors/document-model/editor.tsx
+++ b/editors/document-model/editor.tsx
@@ -37,6 +37,9 @@ function Editor(props: IProps) {
 
     const { state } = document;
 
+    const latestOperation =
+        document.operations.global[document.operations.global.length - 1];
+
     useEffect(() => {
         const ops = [
             ...document.operations.global,
@@ -127,12 +130,14 @@ function Editor(props: IProps) {
         state,
         scope: 'global',
         setInitialState,
+        latestOperation,
     });
 
     const localSchema = useSchemaEditor({
         state,
         scope: 'local',
         setInitialState,
+        latestOperation,
     });
 
     return (
@@ -216,6 +221,7 @@ function Editor(props: IProps) {
                             schemaHandlers={globalSchema}
                             setStateSchema={setStateSchema}
                             name={document.state.global.name}
+                            latestOperation={latestOperation}
                         />
                         <EditorState
                             scope="local"
@@ -223,6 +229,7 @@ function Editor(props: IProps) {
                             schemaHandlers={localSchema}
                             setStateSchema={setStateSchema}
                             name={document.state.global.name}
+                            latestOperation={latestOperation}
                         />
                         {globalSchema.specification.modules.map(m => (
                             <div key={m.id}>

--- a/editors/document-model/useSchemaEditor.ts
+++ b/editors/document-model/useSchemaEditor.ts
@@ -1,8 +1,9 @@
-import { State } from 'document-model/document';
+import { BaseAction, State, Operation } from 'document-model/document';
 import {
     DocumentModelState,
     DocumentModelLocalState,
     DocumentSpecification,
+    DocumentModelAction,
 } from 'document-model/document-model';
 import { useEffect, useState } from 'react';
 import z from 'zod';
@@ -20,6 +21,7 @@ interface UseSchemaEditorProps {
     scope: ScopeType;
     state: State<DocumentModelState, DocumentModelLocalState>;
     setInitialState: (initialValue: string, scope: ScopeType) => void;
+    latestOperation?: Operation<DocumentModelAction | BaseAction> | null;
 }
 
 export interface SchemaResult {
@@ -33,7 +35,7 @@ export interface SchemaResult {
 }
 
 export const useSchemaEditor = (props: UseSchemaEditorProps): SchemaResult => {
-    const { state, scope, setInitialState } = props;
+    const { state, scope, setInitialState, latestOperation } = props;
 
     const stateScope = state.global;
 
@@ -50,7 +52,10 @@ export const useSchemaEditor = (props: UseSchemaEditorProps): SchemaResult => {
     useEffect(() => {
         const currentValue = specScope?.initialValue || '{}';
 
-        if (!isJSONEqual(initialValue, currentValue)) {
+        if (
+            !isJSONEqual(initialValue, currentValue) &&
+            latestOperation?.type !== 'SET_INITIAL_STATE'
+        ) {
             setInitialState(JSON.stringify(initialValue), scope);
         }
     }, [initialValue, specScope?.initialValue]);


### PR DESCRIPTION
## Description:

- Avoid hook infinite loop when set document initial state

![2024-01-08 14 26 50](https://github.com/powerhouse-inc/document-model-libs/assets/20387722/ce862967-1aee-4462-bd88-99a268e9a3d4)
