### PR TITLE
27 improve warn that input type names must match operation names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "document-model-libs",
-    "version": "1.1.27",
+    "version": "1.1.28",
     "license": "AGPL-3.0-only",
     "types": "dist/index.d.ts",
     "main": "dist/index.cjs",


### PR DESCRIPTION
## Description

-  fix restrictions calculation for operations schema

Restriction were not considering an existing schema with different code positions. This commit fixes that issue with a new function that calculates the position of the input and generate the restrictions object.