### PR TITLE
feat: fix pass object reference directly to avoid unexpected behavior

### DIFF
--- a/document-models/real-world-assets/src/reducers/transactions.ts
+++ b/document-models/real-world-assets/src/reducers/transactions.ts
@@ -151,7 +151,7 @@ export const reducer: RealWorldAssetsTransactionsOperations = {
             return {
                 ...existing,
                 ...updates,
-            };
+            } as BaseTransaction;
         }
         let cashTransaction = maybeMakeUpdatedBaseTransaction(
             action.input.cashTransaction,
@@ -192,18 +192,19 @@ export const reducer: RealWorldAssetsTransactionsOperations = {
             validateInterestTransaction(state, interestTransaction);
         }
 
-        const newGroupTransaction = {
-            ...transaction,
-            type,
-            entryTime,
-            cashBalanceChange,
-            cashTransaction,
-            fixedIncomeTransaction,
-            interestTransaction,
-        };
-
         state.transactions = state.transactions.map(t =>
-            t.id === action.input.id ? newGroupTransaction : t,
+            t.id === id
+                ? {
+                      ...t,
+                      id,
+                      type,
+                      entryTime,
+                      cashBalanceChange,
+                      cashTransaction,
+                      fixedIncomeTransaction,
+                      interestTransaction,
+                  }
+                : t,
         );
 
         const fixedIncomeAssetId = fixedIncomeTransaction?.assetId;


### PR DESCRIPTION
Pass by reference for nested base transactions resulted in unexpected behavior when using a map function to update the document model state. This does not happen in storybook but it does in the connect app, I am not sure why. 

Changing to pass object references directly fixes the problem in the connect app. 

