### PR TITLE
feat: remove root dir from ts config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
         "types": ["node", "vitest/globals"],
         "declaration": false,
         "outDir": "./dist",
-        "rootDir": ".",
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Typescript all of a sudden gave errors because of a missing 'rootDir' config in the tsconfig. Adding it fixed the problem, but now it is confusing the export paths when using document-model-libs in the connect app.

I have reverted this for now since it is likely unimportant. We can figure it out later.