### PR TITLE
feat: fix move called when in same dir

### DIFF
--- a/document-models/document-drive/src/reducers/node.ts
+++ b/document-models/document-drive/src/reducers/node.ts
@@ -215,6 +215,12 @@ export const reducer: DocumentDriveNodeOperations = {
         }
     },
     moveNodeOperation(state, action) {
+        if (action.input.srcFolder === action.input.targetParentFolder) {
+            throw new Error(
+                'Circular Reference Error: Attempting to move a node to its current parent folder',
+            );
+        }
+
         const node = state.nodes.find(
             node => node.id === action.input.srcFolder,
         );
@@ -230,11 +236,6 @@ export const reducer: DocumentDriveNodeOperations = {
         });
 
         if (isFolderNode(node)) {
-            if (action.input.srcFolder === action.input.targetParentFolder) {
-                throw new Error(
-                    'Circular Reference Error: Cannot make folder its own parent',
-                );
-            }
             const descendants = getDescendants(node, state.nodes);
             // throw error if moving a folder to one of its descendants
             if (

--- a/document-models/document-drive/src/tests/node.test.ts
+++ b/document-models/document-drive/src/tests/node.test.ts
@@ -423,7 +423,7 @@ describe('Node Operations', () => {
             scope: 'global',
             index: 0,
             skip: 0,
-            error: 'Circular Reference Error: Cannot make folder its own parent',
+            error: 'Circular Reference Error: Attempting to move a node to its current parent folder',
         });
     });
 });


### PR DESCRIPTION
also throw a circular reference error when attempting to move a file to its existing parent. previously we only did this after checking if a node is a folder, but the same reasoning applies here — its redundant.