### PR TITLE
feat: allow legacy asset type check

### DIFF
--- a/document-models/real-world-assets/src/_utils/validators.ts
+++ b/document-models/real-world-assets/src/_utils/validators.ts
@@ -36,12 +36,16 @@ export function isFixedIncomeAsset(
     asset: Asset | undefined | null,
 ): asset is FixedIncome {
     if (!asset) return false;
-    return asset.type === 'FixedIncome';
+    if (asset.type === 'FixedIncome') return true;
+    if ('fixedIncomeId' in asset) return true;
+    return false;
 }
 
 export function isCashAsset(asset: Asset | undefined | null): asset is Cash {
     if (!asset) return false;
-    return asset.type === 'Cash';
+    if (asset.type === 'Cash') return true;
+    if ('currency' in asset) return true;
+    return false;
 }
 
 export function isAssetGroupTransaction(


### PR DESCRIPTION
re-add the old checks for `isCashAsset` and `isFixedIncomeAsset` which check for the presence of unique properties instead of the newly added "type" field.

the function should always return from the first check for any newly created assets, but there are some legacy documents that teep has done work on that have assets created in the old way.

we can remove this again once we are done using those legacy documents.