### PR TITLE
feat: qa updates 3

### DIFF
--- a/document-models/real-world-assets/scripts/createDocumentFromJsonFiles.ts
+++ b/document-models/real-world-assets/scripts/createDocumentFromJsonFiles.ts
@@ -1,0 +1,19 @@
+// import { utils } from '..';
+// import { initialState } from '../mock-data/initial-state';
+// import header from './header.json'
+// import state from './state.json'
+// import operations from './operations.json'
+// import { reducer } from '..';
+
+// let document = utils.createDocument({
+//     state: {
+//         global: initialState,
+//         local: {},
+//     },
+// });
+
+// for (const operation of operations.global) {
+//     document = reducer(document, operation);
+// }
+
+// utils.saveToFile(document, './', 'output');

--- a/editors/rwa/transactions.tsx
+++ b/editors/rwa/transactions.tsx
@@ -163,15 +163,32 @@ export const Transactions = (props: IProps) => {
             feeInputs: EditTransactionFeeInput[] | null | undefined,
             transaction: GroupTransaction,
         ) => {
-            if (!feeInputs) return;
+            const existingFees = transaction.fees;
+
+            // if there are no existing fees and no fees to update, we do nothing
+            if (!existingFees?.length && !feeInputs?.length) return;
+
+            // if there are existing fees and the update is empty, then we remove all fees
+            if (existingFees?.length && !feeInputs?.length) {
+                dispatch(
+                    removeFeesFromGroupTransaction({
+                        id: transaction.id,
+                        feeIds: existingFees.map(fee => fee.id),
+                    }),
+                );
+                return;
+            }
+
+            // once we have handled the edge cases, we can assume that there are fees to update
+            if (!feeInputs) {
+                throw new Error('Fees are required');
+            }
 
             const feeUpdates = feeInputs.map(fee => ({
                 ...fee,
                 id: fee.id ?? utils.hashKey(),
                 amount: Number(fee.amount),
             }));
-
-            const existingFees = transaction.fees;
 
             if (!existingFees?.length) {
                 validateTransactionFees(document.state.global, feeUpdates);


### PR DESCRIPTION
when the user changes the asset a given fixed income transaction points to, we must compute the derived fields for both the old _and_ the new asset to avoid double counting.

the "fees" field of a transaction can be an array or null. do not dispatch a change action when the input is an empty array and the "fees" are null.