### PR TITLE
feat: handle orphans

### DIFF
--- a/editors/rwa/other/accounts.tsx
+++ b/editors/rwa/other/accounts.tsx
@@ -26,6 +26,9 @@ export function Accounts(props: IProps) {
     const principalLenderAccountId =
         document.state.global.principalLenderAccountId;
     const accounts = document.state.global.accounts;
+    const transactions = document.state.global.transactions;
+    const serviceProviderFeeTypes =
+        document.state.global.serviceProviderFeeTypes;
 
     const toggleExpandedRow = useCallback(
         (id: string | undefined) => {
@@ -94,6 +97,8 @@ export function Accounts(props: IProps) {
     return (
         <AccountsTable
             accounts={accounts}
+            transactions={transactions}
+            serviceProviderFeeTypes={serviceProviderFeeTypes}
             selectedItem={selectedItem}
             showNewItemForm={showNewItemForm}
             expandedRowId={expandedRowId}

--- a/editors/rwa/other/fixed-income-types.tsx
+++ b/editors/rwa/other/fixed-income-types.tsx
@@ -7,8 +7,10 @@ import { copy } from 'copy-anything';
 import { utils } from 'document-model/document';
 import { useCallback, useState } from 'react';
 import {
+    FixedIncome,
     actions,
     getDifferences,
+    isFixedIncomeAsset,
 } from '../../../document-models/real-world-assets';
 import { IProps } from '../editor';
 
@@ -25,6 +27,9 @@ export function FixedIncomeTypes(props: IProps) {
     } = props;
 
     const fixedIncomeTypes = document.state.global.fixedIncomeTypes;
+    const assets = document.state.global.portfolio.filter(a =>
+        isFixedIncomeAsset(a),
+    ) as FixedIncome[];
 
     const toggleExpandedRow = useCallback(
         (id: string | undefined) => {
@@ -88,6 +93,7 @@ export function FixedIncomeTypes(props: IProps) {
     return (
         <FixedIncomeTypesTable
             fixedIncomeTypes={fixedIncomeTypes}
+            assets={assets}
             selectedItem={selectedItem}
             showNewItemForm={showNewItemForm}
             expandedRowId={expandedRowId}

--- a/editors/rwa/other/service-provider-fee-types.tsx
+++ b/editors/rwa/other/service-provider-fee-types.tsx
@@ -27,6 +27,7 @@ export function ServiceProviderFeeTypes(props: IProps) {
     const serviceProviderFeeTypes =
         document.state.global.serviceProviderFeeTypes;
     const accounts = document.state.global.accounts;
+    const transactions = document.state.global.transactions;
 
     const toggleExpandedRow = useCallback(
         (id: string | undefined) => {
@@ -106,6 +107,7 @@ export function ServiceProviderFeeTypes(props: IProps) {
         <ServiceProviderFeeTypesTable
             serviceProviderFeeTypes={serviceProviderFeeTypes}
             accounts={accounts}
+            transactions={transactions}
             selectedItem={selectedItem}
             showNewItemForm={showNewItemForm}
             expandedRowId={expandedRowId}

--- a/editors/rwa/other/spvs.tsx
+++ b/editors/rwa/other/spvs.tsx
@@ -3,8 +3,10 @@ import { copy } from 'copy-anything';
 import { utils } from 'document-model/document';
 import { useCallback, useState } from 'react';
 import {
+    FixedIncome,
     actions,
     getDifferences,
+    isFixedIncomeAsset,
 } from '../../../document-models/real-world-assets';
 import { IProps } from '../editor';
 
@@ -21,6 +23,9 @@ export function SPVs(props: IProps) {
     } = props;
 
     const spvs = document.state.global.spvs;
+    const assets = document.state.global.portfolio.filter(a =>
+        isFixedIncomeAsset(a),
+    ) as FixedIncome[];
 
     const toggleExpandedRow = useCallback(
         (id: string | undefined) => {
@@ -86,6 +91,7 @@ export function SPVs(props: IProps) {
     return (
         <SPVsTable
             spvs={spvs}
+            assets={assets}
             selectedItem={selectedItem}
             showNewItemForm={showNewItemForm}
             expandedRowId={expandedRowId}

--- a/editors/rwa/portfolio.tsx
+++ b/editors/rwa/portfolio.tsx
@@ -36,6 +36,8 @@ export const Portfolio = (props: IProps) => {
         (asset): asset is FixedIncome => isFixedIncomeAsset(asset),
     );
 
+    const transactions = document.state.global.transactions;
+
     // there is only one cash asset for v1
     // this is always defined for every document model
     const cashAsset = document.state.global.portfolio.find(
@@ -143,6 +145,7 @@ export const Portfolio = (props: IProps) => {
             </p>
             <AssetsTable
                 assets={fixedIncomeAssets as UiFixedIncome[]}
+                transactions={transactions}
                 cashAsset={cashAsset}
                 fixedIncomeTypes={fixedIncomeTypes}
                 spvs={spvs}

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "@monaco-editor/react": "^4.6.0",
         "@mui/material": "^5.15.5",
         "@powerhousedao/codegen": "0.0.15",
-        "@powerhousedao/design-system": "1.0.0-alpha.109",
+        "@powerhousedao/design-system": "1.0.0-alpha.110",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@storybook/addon-essentials": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "@monaco-editor/react": "^4.6.0",
         "@mui/material": "^5.15.5",
         "@powerhousedao/codegen": "0.0.15",
-        "@powerhousedao/design-system": "1.0.0-alpha.110",
+        "@powerhousedao/design-system": "1.0.0-alpha.111",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@storybook/addon-essentials": "^8.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ devDependencies:
     specifier: 0.0.15
     version: 0.0.15(graphql@16.8.1)(zod@3.22.4)
   '@powerhousedao/design-system':
-    specifier: 1.0.0-alpha.109
-    version: 1.0.0-alpha.109(@types/react@18.2.57)(react-aria-components@1.1.1)(react-aria@3.32.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 1.0.0-alpha.110
+    version: 1.0.0-alpha.110(@types/react@18.2.57)(react-aria-components@1.1.1)(react-aria@3.32.1)(react-dom@18.2.0)(react@18.2.0)
   '@semantic-release/changelog':
     specifier: ^6.0.3
     version: 6.0.3(semantic-release@23.0.2)
@@ -3803,8 +3803,8 @@ packages:
       - zod
     dev: true
 
-  /@powerhousedao/design-system@1.0.0-alpha.109(@types/react@18.2.57)(react-aria-components@1.1.1)(react-aria@3.32.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-qNLDL8AaZ4+3g+5rJ7G7b8SjjovDNlZ3S1l2W7h2Wf5cfET4ZPAAEUZ1JmkFfkbLkj2goUu8fjsnYv8odXEH9w==}
+  /@powerhousedao/design-system@1.0.0-alpha.110(@types/react@18.2.57)(react-aria-components@1.1.1)(react-aria@3.32.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-kZrk2lp+Vp1Xf+RpyTVuaRCszqbDwiD8Gj3oXB/2KjEhEZzdbNUhdmMxoX9h/WEQlLD6hVGe8a3LqzMWquvvHA==}
     peerDependencies:
       react: ^18.2.0
       react-aria: ^3.32.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ devDependencies:
     specifier: 0.0.15
     version: 0.0.15(graphql@16.8.1)(zod@3.22.4)
   '@powerhousedao/design-system':
-    specifier: 1.0.0-alpha.110
-    version: 1.0.0-alpha.110(@types/react@18.2.57)(react-aria-components@1.1.1)(react-aria@3.32.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 1.0.0-alpha.111
+    version: 1.0.0-alpha.111(@types/react@18.2.57)(react-aria-components@1.1.1)(react-aria@3.32.1)(react-dom@18.2.0)(react@18.2.0)
   '@semantic-release/changelog':
     specifier: ^6.0.3
     version: 6.0.3(semantic-release@23.0.2)
@@ -3803,8 +3803,8 @@ packages:
       - zod
     dev: true
 
-  /@powerhousedao/design-system@1.0.0-alpha.110(@types/react@18.2.57)(react-aria-components@1.1.1)(react-aria@3.32.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-kZrk2lp+Vp1Xf+RpyTVuaRCszqbDwiD8Gj3oXB/2KjEhEZzdbNUhdmMxoX9h/WEQlLD6hVGe8a3LqzMWquvvHA==}
+  /@powerhousedao/design-system@1.0.0-alpha.111(@types/react@18.2.57)(react-aria-components@1.1.1)(react-aria@3.32.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-o9VaAdXaEU0ulokgQ1+NukCkEN93EQL193h3gNaTANLIgxSTdm5vfyx5/RlmIM3HV/uDYW3S9agVUtp8eMzBZw==}
     peerDependencies:
       react: ^18.2.0
       react-aria: ^3.32.0


### PR DESCRIPTION
add checks to reducers which prevent delete operations which would result in orphaned objects. these checks are separate from the ui, which will also prevent these actions and provide more information to the user about the objects that would be orphaned.